### PR TITLE
Add identifier to pipe name

### DIFF
--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -22,7 +22,7 @@
 # Copyright (C) 2016 Suhas
 # Copyright (C) 2016-2018 Sambhav Kothari
 # Copyright (C) 2017-2018 Vishal Choudhary
-# Copyright (C) 2018 Bob Swift
+# Copyright (C) 2018, 2022 Bob Swift
 # Copyright (C) 2018 virusMac
 # Copyright (C) 2019 Joel Lintunen
 # Copyright (C) 2020 Julius Michaelis
@@ -47,6 +47,7 @@
 import argparse
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
+from hashlib import md5
 import itertools
 import logging
 import os
@@ -57,6 +58,7 @@ import signal
 import sys
 from textwrap import fill
 from urllib.parse import urlparse
+from uuid import uuid4
 
 from PyQt5 import (
     QtCore,
@@ -1269,6 +1271,15 @@ class PicardArgs:
         self.version = self.__get_version(short=argparse_args.version, long=argparse_args.long_version)
         self.__parse_loadable_items()
 
+    # Add string output for debugging purposes
+    def __str__(self):
+        return_string = '{\n'
+        for _attribute in ['config_file', 'debug', 'no_player', 'no_restore', 'no_plugins', 'no_crash_dialog',
+                'stand_alone_instance', 'version', 'processable']:
+            return_string += f"  '{_attribute}': {getattr(self, _attribute, None)}\n"
+        return_string += '}'
+        return return_string
+
     def __parse_loadable_items(self):
         for x in self._file_or_url:
             if not urlparse(x).netloc:
@@ -1394,32 +1405,28 @@ def main(localedir=None, autoupdate=True):
         return print(picard_args.version)
 
     # any of the flags that change Picard's workflow significantly should trigger creation of a new instance
-    should_start = True in {
-        picard_args.config_file is not None,
-        picard_args.no_plugins,
-        picard_args.stand_alone_instance,
-    }
-    if not should_start:
-        if picard_args.processable:
-            log.info("Sending messages to main instance: %r", picard_args.processable)
+    identifier = md5(picard_args.config_file.encode('utf8')).hexdigest() if picard_args.config_file else 'main'
+    identifier += '_NP' if picard_args.no_plugins else ''
+    if picard_args.stand_alone_instance:
+        identifier = uuid4().hex
 
-        try:
-            pipe_handler = pipe.Pipe(app_name=PICARD_APP_NAME, app_version=PICARD_FANCY_VERSION_STR,
-                                     args=picard_args.processable)
-            should_start = pipe_handler.is_pipe_owner
-        except pipe.PipeErrorNoPermission as err:
-            log.error(err)
-            pipe_handler = None
-            should_start = True
+    if picard_args.processable:
+        log.info("Sending messages to main instance: %r", picard_args.processable)
 
-        # pipe has sent its args to existing one, doesn't need to start
-        if not should_start:
-            log.debug("No need for spawning a new instance, exiting...")
-            # just a custom exit code to show that picard instance wasn't created
-            sys.exit(EXIT_NO_NEW_INSTANCE)
-
-    else:
+    try:
+        pipe_handler = pipe.Pipe(app_name=PICARD_APP_NAME, app_version=PICARD_FANCY_VERSION_STR,
+                                    identifier=identifier, args=picard_args.processable)
+        should_start = pipe_handler.is_pipe_owner
+    except pipe.PipeErrorNoPermission as err:
+        log.error(err)
         pipe_handler = None
+        should_start = True
+
+    # pipe has sent its args to existing one, doesn't need to start
+    if not should_start:
+        log.debug("No need for spawning a new instance, exiting...")
+        # just a custom exit code to show that picard instance wasn't created
+        sys.exit(EXIT_NO_NEW_INSTANCE)
 
     try:
         from PyQt5.QtDBus import QDBusConnection

--- a/picard/tagger.py
+++ b/picard/tagger.py
@@ -1273,12 +1273,9 @@ class PicardArgs:
 
     # Add string output for debugging purposes
     def __str__(self):
-        return_string = '{\n'
-        for _attribute in ['config_file', 'debug', 'no_player', 'no_restore', 'no_plugins', 'no_crash_dialog',
-                'stand_alone_instance', 'version', 'processable']:
-            return_string += f"  '{_attribute}': {getattr(self, _attribute, None)}\n"
-        return_string += '}'
-        return return_string
+        attributes = ('config_file', 'debug', 'no_player', 'no_restore', 'no_plugins',
+            'no_crash_dialog', 'stand_alone_instance', 'version', 'processable')
+        return str({a: getattr(self, a, None) for a in attributes})
 
     def __parse_loadable_items(self):
         for x in self._file_or_url:
@@ -1405,10 +1402,11 @@ def main(localedir=None, autoupdate=True):
         return print(picard_args.version)
 
     # any of the flags that change Picard's workflow significantly should trigger creation of a new instance
-    identifier = md5(picard_args.config_file.encode('utf8')).hexdigest() if picard_args.config_file else 'main'
-    identifier += '_NP' if picard_args.no_plugins else ''
     if picard_args.stand_alone_instance:
         identifier = uuid4().hex
+    else:
+        identifier = md5(picard_args.config_file.encode('utf8')).hexdigest() if picard_args.config_file else 'main'
+        identifier += '_NP' if picard_args.no_plugins else ''
 
     if picard_args.processable:
         log.info("Sending messages to main instance: %r", picard_args.processable)

--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -139,7 +139,7 @@ class AbstractPipe(metaclass=ABCMeta):
         if not isinstance(app_name, str) or not isinstance(app_version, str):
             raise PipeErrorInvalidAppData
 
-        self._identifier = str(identifier).replace(' ', '_') if identifier else 'main'
+        self._identifier = identifier.replace(' ', '_') if identifier else 'main'
 
         if forced_path:
             self._paths = (forced_path,)

--- a/picard/util/pipe.py
+++ b/picard/util/pipe.py
@@ -4,6 +4,7 @@
 #
 # Copyright (C) 2022 skelly37
 # Copyright (C) 2022 Philipp Wolfer
+# Copyright (C) 2022 Bob Swift
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -115,11 +116,12 @@ class AbstractPipe(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
-    def __init__(self, app_name: str, app_version: str, args: Optional[Iterable[str]] = None,
+    def __init__(self, app_name: str, app_version: str, identifier: Optional[str] = None, args: Optional[Iterable[str]] = None,
                  forced_path: Optional[str] = None):
         """
         :param app_name: (str) Name of the app, included in the pipe name
         :param app_version: (str) Version of the app, included in the pipe name
+        :param identifier: (Optional[str]) config file / standalone identifier, included in pipe name
         :param args: (Optional[Iterable[str]]) Will be passed to an existing instance of app if possible
         :param forced_path: (Optional[str]) Testing-purposes only, bypass of no $HOME on testing machines
         """
@@ -136,6 +138,8 @@ class AbstractPipe(metaclass=ABCMeta):
 
         if not isinstance(app_name, str) or not isinstance(app_version, str):
             raise PipeErrorInvalidAppData
+
+        self._identifier = str(identifier).replace(' ', '_') if identifier else 'main'
 
         if forced_path:
             self._paths = (forced_path,)
@@ -190,7 +194,7 @@ class AbstractPipe(metaclass=ABCMeta):
         for directory in self.PIPE_DIRS:
             if directory:
                 _pipe_names.append(os.path.join(os.path.expanduser(directory),
-                                                f"{app_name}_v{app_version}_pipe_file"))
+                                                f"{app_name}_v{app_version}_{self._identifier}_pipe_file"))
 
         if _pipe_names:
             return _pipe_names
@@ -279,7 +283,7 @@ class UnixPipe(AbstractPipe):
         "~/.config/MusicBrainz/Picard/pipes/",
     )   # type: ignore
 
-    def __init__(self, app_name: str, app_version: str, args: Optional[Iterable[str]] = None,
+    def __init__(self, app_name: str, app_version: str, identifier: Optional[str] = None,  args: Optional[Iterable[str]] = None,
                  forced_path: Optional[str] = None):
         super().__init__(app_name, app_version, args, forced_path)
 
@@ -371,7 +375,7 @@ class WinPipe(AbstractPipe):
 
     PIPE_DIRS: Tuple[str] = ("\\\\.\\pipe\\",)
 
-    def __init__(self, app_name: str, app_version: str, args: Optional[Iterable[str]] = None,
+    def __init__(self, app_name: str, app_version: str, identifier: Optional[str] = None,  args: Optional[Iterable[str]] = None,
                  forced_path: Optional[str] = None):
         # type checking is already enforced in the AbstractPipe
         try:


### PR DESCRIPTION
# Summary

* This is a…
  * [x] Bug fix
  * [x] Feature addition
  * [ ] Refactoring
  * [ ] Minor / simple change (like a typo)
  * [ ] Other
* **Describe this change in 1-2 sentences**:

# Problem

Command line arguments (files and commands) were not being processed for Picard when started with a `-c`, `-P` or `-s` option.  It is quite common (at least for me) to use `-c` for testing so that I don't inadvertently change my normal configuration file.

* JIRA ticket (_optional_): PICARD-XXX
<!--
    Please make sure you prefix your pull request title with 'PICARD-XXX' in order
    for our ticket tracker to link your pull request to the relevant ticket.
-->



# Solution

Add an `identifier` to the pipe name to allow creating pipes for all running instances to ensure that all of the command line options are processed.  The `identifier` is a combination of the config file (if specified) hash and a `-P` indicator.  If `-s` is specified, a unique UUID identifier is used.

# Action

None.